### PR TITLE
Changing the order of parameter checks

### DIFF
--- a/src/acap_runtime.cpp
+++ b/src/acap_runtime.cpp
@@ -257,7 +257,7 @@ int AcapRuntime(int argc, char* argv[])
   }
 
   // Skipped if command line parameters are provided.
-  if(parameter_flag == 0 ){
+  if (parameter_flag == 0) {
     LOG(INFO) << "No command line parameters detected, reading parameters from storage" << argv[0] << endl;
     // Read parameters from parameter storage
     char *verbose = get_parameter_value(APP_NAME, "Verbose");


### PR DESCRIPTION
Change-Id: Icfa4eefaa2fbd0ece5b04a3b7deea2cb41d4c8b1

### Describe your changes

Now the run-time application checks for command lines parameters before checking for acap parameters. in this way we avoid the long waiting time when the acap is used as a docker image. 

### Issue ticket number and link

- Fixes [#(issue)](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/issues/28)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
