### PR TITLE
Adding flag to avoid overriding of command line parameters

### DIFF
--- a/src/acap_runtime.cpp
+++ b/src/acap_runtime.cpp
@@ -221,7 +221,7 @@ void Usage(const char* name)
    << "  -v    Verbose" << endl
    << "  -a    IP address of server" << endl
    << "  -p    IP port of server" << endl
-   << "  -o    Do not read parameters from ACAP storage " << endl
+   << "  -o    Do not read settings from device parameters " << endl
    << "  -j    Chip id (see larodChip in larod.h)" << endl
    << "  -t    Runtime in seconds (used for test)" << endl
    << "  -c    Certificate file for TLS authentication, insecure channel if omitted" << endl


### PR DESCRIPTION
### Describe your changes

Switching priority of command line over parameter storage and add flag to avoid reading storage
### Issue ticket number and link

- Fixes [#(issue)](https://github.com/AxisCommunications/acap-runtime/issues/17)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
