### PR TITLE
Change of how PKG_CONFIG_CFLAGS are generated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,19 @@ SRC_FILES := $(wildcard $(SRC_PATH)/*.cpp $(SRC_PATH)/*.cc)
 TEST_FILES := $(wildcard $(TEST_PATH)/*.cpp $(TEST_PATH)/*.cc)
 
 # Compiler flags
-PKGS = protobuf grpc grpc++ gio-2.0 glib-2.0 
-PKG_CONFIG_CFLAGS_I := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags-only-I $(PKGS))
-PKG_CONFIG_CFLAGS_OTHER := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags-only-other $(PKGS))
-PKG_CONFIG_LDFLAGS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs-only-L $(PKGS))
-PKG_CONFIG_LDLIBS := $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs-only-l $(PKGS))
+# gRPC and protobuf packages don't play well with pkg-config for include so we do a little workaround
+
+PKGS = protobuf grpc grpc++
+PKG_CONFIG_CFLAGS_I := $(shell PKG_CONFIG_SYSROOT_DIR="" PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags-only-I $(PKGS))
+PKG_CONFIG_CFLAGS_OTHER := $(shell PKG_CONFIG_SYSROOT_DIR="" PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags-only-other $(PKGS))
+PKG_CONFIG_LDFLAGS := $(shell PKG_CONFIG_SYSROOT_DIR="" PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs-only-L $(PKGS))
+PKG_CONFIG_LDLIBS := $(shell PKG_CONFIG_SYSROOT_DIR="" PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs-only-l $(PKGS))
+
+PKGS = gio-2.0 glib-2.0
+PKG_CONFIG_CFLAGS_I += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags-only-I $(PKGS))
+PKG_CONFIG_CFLAGS_OTHER += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags-only-other $(PKGS))
+PKG_CONFIG_LDFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs-only-L $(PKGS))
+PKG_CONFIG_LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs-only-l $(PKGS))
 CXXFLAGS += -DLAROD_API_VERSION_2 -std=c++17 -I$(OUT_PATH) $(PKG_CONFIG_CFLAGS_OTHER) $(PKG_CONFIG_CFLAGS_I)
 LDLIBS   += -llarod -lrt $(PKG_CONFIG_LDLIBS)
 LDFLAGS  += $(PKG_CONFIG_LDFLAGS)


### PR DESCRIPTION
### Describe your changes
Fixes issue that caused multiple "directory does not exist" warnings when using the Makefile to build

### Issue ticket number and link

- Fixes #(issue)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
