### PR TITLE
Override flag change

### DIFF
--- a/manifest-aarch64.json
+++ b/manifest-aarch64.json
@@ -11,6 +11,7 @@
                 "username": "sdk"
             },
             "vendorUrl": "https://www.axis.com",
+            "runOptions": "-o",
             "runMode": "once",
             "version": "1.1.2"
         },

--- a/manifest-armv7hf.json
+++ b/manifest-armv7hf.json
@@ -12,6 +12,7 @@
             },
             "vendorUrl": "https://www.axis.com",
             "runMode": "once",
+            "runOptions": "-o",
             "version": "1.1.2"
         },
         "configuration": {

--- a/src/acap_runtime.cpp
+++ b/src/acap_runtime.cpp
@@ -182,7 +182,7 @@ void Usage(const char* name)
    << "  -v    Verbose" << endl
    << "  -a    IP address of server" << endl
    << "  -p    IP port of server" << endl
-   << "  -o    Do not read settings from device parameters " << endl
+   << "  -o    Read settings from device parameters" << endl
    << "  -j    Chip id (see larodChip in larod.h)" << endl
    << "  -t    Runtime in seconds (used for test)" << endl
    << "  -c    Certificate file for TLS authentication, insecure channel if omitted" << endl
@@ -200,7 +200,7 @@ int AcapRuntime(int argc, char* argv[])
  string key_file = "";
  uint64_t chipId = 0;
  int time = 0; // Run time in seconds, 0 => infinity
- bool allow_override = true;
+ bool allow_override = false;
  openlog(NULL, LOG_PID, LOG_USER);
  
  // Setup signal handling.
@@ -234,7 +234,7 @@ int AcapRuntime(int argc, char* argv[])
        _verbose = true;
        break;
      case 'o':
-       allow_override = false;
+       allow_override = true;
        break;
      case 'c':
        pem_file.assign(optarg);
@@ -249,7 +249,6 @@ int AcapRuntime(int argc, char* argv[])
  }
   if(allow_override){
     // Override with parameters from parameter storage
-
     const char *verbose = get_parameter_value("Verbose");
     if (verbose != NULL) {
       _verbose = strcmp(verbose, "yes") == 0;

--- a/test/inference_test.cc
+++ b/test/inference_test.cc
@@ -57,8 +57,7 @@ void Service(
     "acapruntime", verbose ? "-v" : "",
     "-p", target_port,
     "-t", timeout,
-    "-j", chipId,
-    "-o"
+    "-j", chipId
      };
   const int argc = sizeof(argv) / sizeof(const char*);
   ASSERT_EQ(0, AcapRuntime(argc, (char**)argv));
@@ -79,8 +78,7 @@ void ServiceSecurity(
     "-t", timeout,
     "-j", chipId,
     "-c", certificateFile,
-    "-k", keyFile,
-    "-o"
+    "-k", keyFile
      };
   const int argc = sizeof(argv) / sizeof(const char*);
   ASSERT_EQ(0, AcapRuntime(argc, (char**)argv));
@@ -99,8 +97,7 @@ void ServiceModel(
     "-p", target_port,
     "-t", timeout,
     "-j", chipId,
-    "-m", modelFile,
-    "-o"
+    "-m", modelFile
      };
   const int argc = sizeof(argv) / sizeof(const char*);
   ASSERT_EQ(0, AcapRuntime(argc, (char**)argv));


### PR DESCRIPTION
Changed override flag (-o) in acap_runtime.cpp to mean true when set. 

### Describe your changes

ACAP runtime can be used either as a native ACAP application or a container and in order to make it less confusing for a user if device parameters are to be used or not we want to change the meaning of the override flag so that:

- if not set only the command line settings are used
- if set the device parameters will be used (and possibly override given command line settings)

This change will require the examples in [acap-computer-vision-sdk](https://github.com/AxisCommunications/acap-computer-vision-sdk) to be updated as well

Please include a summary of the change, a relevant motivation and context.

### Issue ticket number and link

- Relates to #([17](https://github.com/AxisCommunications/acap-runtime/issues/17))

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
