### PR TITLE
Update inference.cpp

### DIFF
--- a/src/inference.cpp
+++ b/src/inference.cpp
@@ -310,18 +310,17 @@ Status Inference::Predict(
 
 predict_error:
   // Cleanup
-  larodClearError(&error);
   larodDestroyTensors(&_ppInputTensors, _ppNumInputs);
   larodDestroyTensors(&_ppOutputTensors, _ppNumOutputs);
   larodDestroyTensors(&_inputTensors, _numInputs);
   larodDestroyTensors(&_outputTensors, _numOutputs);
   larodDestroyMap(&_ppMap);
-  larodDeleteModel(&_conn, &_ppModel, nullptr)
+  larodDeleteModel(_conn, _ppModel, &error);
   larodDestroyModel(&_ppModel);
   CloseTmpFiles(inFiles);
   CloseTmpFiles(outFiles);
   pthread_mutex_unlock(&_mtx);
-
+  larodClearError(&error);
   return status;
 }
 


### PR DESCRIPTION
### Describe your changes

There are two issue that we try to solve with this patch

The preprocessing model is loaded many times, and only destroyed, but not deleted from the larod server.
Following the [larod documentation](https://gittools.se.axis.com/gerrit/plugins/gitiles/apps/larod/+/refs/heads/master/lib/larod.h#836) the model should be deleted before destroying it, otherwise it will still stay loaded in the larod server.

Another issue, is that also the main model (not the pre-processing) is not deleted. That is fine, because it is loaded only once, but at the moment, it will stay loaded in the larod server even after closing the app.
With the [new patch](https://gittools.se.axis.com/gerrit/c/apps/larod/+/742243) to larod, it will be possible to load only 64 models, that means that after running an example 64 times larod will refuse to load the model.
This other issue is fixed by changing the parameter access to LAROD_ACCESS_PRIVATE. A model loaded in this way will be automatically removed from larod when the application stops, solving also this other issue.

Credit to Waqar for spotting the bug and suggesting a solution.

Extra note: At the moment, the pre-processing model, is loaded and unloaded every time. This is inefficient, we could make another patch to load it only once and reuse the same pre-processing model.

### Issue ticket number and link

- [Fixes #(issue)](https://github.com/AxisCommunications/acap-runtime/issues/37)

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
