### PR TITLE
Adding appId to prepare for ACAP signing and update sdk version

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -2,7 +2,7 @@
 
 ARG ARCH=aarch64
 ARG REPO=axisecp
-ARG VERSION=1.3
+ARG VERSION=1.6
 ARG UBUNTU_VERSION=22.04
 
 FROM ${REPO}/acap-native-sdk:${VERSION}-${ARCH}-ubuntu${UBUNTU_VERSION} as acap-native-sdk

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -2,7 +2,7 @@
 
 ARG ARCH=aarch64
 ARG REPO=axisecp
-ARG VERSION=1.6
+ARG VERSION=1.5
 ARG UBUNTU_VERSION=22.04
 
 FROM ${REPO}/acap-native-sdk:${VERSION}-${ARCH}-ubuntu${UBUNTU_VERSION} as acap-native-sdk

--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -2,7 +2,7 @@
 
 ARG ARCH=armv7hf
 ARG REPO=axisecp
-ARG VERSION=1.3
+ARG VERSION=1.6
 ARG UBUNTU_VERSION=22.04
 
 FROM ${REPO}/acap-native-sdk:${VERSION}-${ARCH}-ubuntu${UBUNTU_VERSION} as acap-native-sdk

--- a/Dockerfile.armv7hf
+++ b/Dockerfile.armv7hf
@@ -2,7 +2,7 @@
 
 ARG ARCH=armv7hf
 ARG REPO=axisecp
-ARG VERSION=1.6
+ARG VERSION=1.5
 ARG UBUNTU_VERSION=22.04
 
 FROM ${REPO}/acap-native-sdk:${VERSION}-${ARCH}-ubuntu${UBUNTU_VERSION} as acap-native-sdk

--- a/manifest-aarch64.json
+++ b/manifest-aarch64.json
@@ -3,6 +3,7 @@
     "acapPackageConf": {
         "setup": {
             "friendlyName": "ACAP Runtime",
+            "appId": "414174",
             "appName": "acapruntime",
             "vendor": "Axis Communications",
             "embeddedSdkVersion": "3.0",

--- a/manifest-armv7hf.json
+++ b/manifest-armv7hf.json
@@ -3,6 +3,7 @@
     "acapPackageConf": {
         "setup": {
             "friendlyName": "ACAP Runtime",
+            "appId": "414174",
             "appName": "acapruntime",
             "vendor": "Axis Communications",
             "embeddedSdkVersion": "3.0",


### PR DESCRIPTION
### Describe your changes

AppId is required in order to sign an ACAP in ACAP Portal
Updated version of sdk to 1.5 
