### PR TITLE
Set provenance to default off when building containerized image

### DIFF
--- a/.github/actions/docker-build-push-action/action.yml
+++ b/.github/actions/docker-build-push-action/action.yml
@@ -54,6 +54,11 @@ inputs:
     description: Token/password for the user on the the remote registry.
       Required if push is true.
     required: false
+  provenance:
+    description: Generate provenance attestation for the build
+      (shorthand for --attest=type=provenance). Default false.
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -81,3 +86,4 @@ runs:
         tags: ${{ inputs.tags }}
         labels: ${{ inputs.labels }}
         target: ${{ inputs.target }}
+        provenance: ${{ inputs.provenance }}


### PR DESCRIPTION
### Describe your changes

Set adding provenance to default off when building docker images

Rationale:
The action `docker/build-and-push` that we use to build (and push) the containerized Acap Runtime is adding provenance to the docker image per default. Since older versions of docker seem to have trouble pulling images with provenance we should build without it for the time being.

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [X] I have made corresponding changes to the documentation
