### PR TITLE
Remove cpp examples from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,11 +337,10 @@ ACAP application:
 
 - [parameter-api-python][parameter-api-python]
 
-The following examples use the ACAP Runtime containerized version to use the
+The following example use the ACAP Runtime containerized version to use the
 Machine learning API service:
 
 - [minimal-ml-inference][minimal-ml-inference]
-
 
 ## Building ACAP Runtime
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ The ACAP Runtime service provides the following APIs:
   There are usage examples available for the Parameter API written in
   [Python][parameter-api-python].
 - Video capture API - Enables capture of images from a camera.
-  There are usage examples available for the Parameter API written in
-  [Python][opencv-qr-decoder-python].
+  No usage examples for this API exist yet.
 
 ## Installation and usage
 

--- a/README.md
+++ b/README.md
@@ -93,12 +93,13 @@ The ACAP Runtime service provides the following APIs:
 
 - Machine learning API - An implementation of [TensorFlow Serving][tensorflow]. There
   are usage examples available for the Machine learning API written in
-  [Python][minimal-ml-inference] and [C++][object-detector-cpp].
+  [Python][minimal-ml-inference].
 - Parameter API - Provides gRPC read access to the parameters of an Axis device.
   There are usage examples available for the Parameter API written in
-  [Python][parameter-api-python] and [C++][paramter-api-cpp].
-- Video capture API - Enables capture of images from a camera. No usage examples
-  for this API exist yet.
+  [Python][parameter-api-python].
+- Video capture API - Enables capture of images from a camera.
+  There are usage examples available for the Parameter API written in
+  [Python][opencv-qr-decoder-python].
 
 ## Installation and usage
 
@@ -110,7 +111,7 @@ The native ACAP Runtime application is available as a **signed** eap-file in [Re
 
 The prebuilt native ACAP Runtime application is signed, read more about signing [here][signing-documentation].
 
-The recomended way of installing and use ACAP Runtime is to download the signed eap-file from [prereleases or releases][all-releases] with a tag on the form `<version>_<ARCH>`, where `<version>` is the acap-runtime release
+The recommended way of installing and using ACAP Runtime is to download the signed eap-file from [prereleases or releases][all-releases] with a tag on the form `<version>_<ARCH>`, where `<version>` is the acap-runtime release
 version and `<ARCH>` is either `armv7hf` or `aarch64` depending on device architecture.
 E.g. `ACAP_Runtime_1_2_2_armv7hf_signed.eap`.
 The eap-file can be installed as an ACAP application on the device,
@@ -157,7 +158,7 @@ Pre-built containerized images are available on
 To include the containerized ACAP Runtime server in a project, add the image in
 the projects `docker-compose.yml` file. The following is an illustrative
 example of how the service can be set up with docker-compose. Here we use the
-image for `armv7hf`architecture. For a complete description
+image for `armv7hf` architecture. For a complete description
 see one of the working project [examples](#examples).
 
 ```yml
@@ -244,7 +245,7 @@ be given. See [Chip id](#chip-id) for more information.
 
 **(4)** If an instance of ACAP Runtime as an ACAP application is installed on the
 device, the device parameters are also available. Setting the `-o` flag will
-then override the -v, -p, -j and -c and -k settings, if the the corresponding
+then override the -v, -p, -j and -c and -k settings, if the corresponding
 device parameter value is valid. This setting is mainly aimed at debug/test
 usage and should not be used in production.
 
@@ -252,7 +253,7 @@ usage and should not be used in production.
 
 The Machine learning API uses the [Machine learning API][acap-documentation-native-ml] for image processing
 and to set it up the correct chip id for the device needs to be selected.
-Note that there is no direct corelation between chip id and architecture.
+Note that there is no direct correlation between chip id and architecture.
 For convenience the pre-built images for the ACAP Runtime native application sets
 the default value for ChipId to 4 for `armv7hf` and 12 for `aarch64`, since those
 are currently the most common ids for the respective architectures.
@@ -331,17 +332,16 @@ ACAP application or the `-a` and `-p` settings for the containerized version.
 
 ### Examples
 
-The following examples use the Parameter API with ACAP Runtime as a native
+The following example use the Parameter API with ACAP Runtime as a native
 ACAP application:
 
-- [parameter-api-cpp][paramter-api-cpp]
 - [parameter-api-python][parameter-api-python]
 
 The following examples use the ACAP Runtime containerized version to use the
 Machine learning API service:
 
 - [minimal-ml-inference][minimal-ml-inference]
-- [object-detector-cpp][object-detector-cpp]
+
 
 ## Building ACAP Runtime
 
@@ -458,10 +458,9 @@ Take a look at the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 [gRPC]: https://grpc.io/
 [latest-releases]: https://github.com/AxisCommunications/acap-runtime/releases/latest
 [minimal-ml-inference]: https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/tree/main/minimal-ml-inference
-[object-detector-cpp]: https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/tree/main/object-detector-cpp
 [openssl-req]: https://www.openssl.org/docs/man3.0/man1/openssl-req.html
 [parameter-api-python]: https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/tree/main/parameter-api-python
-[paramter-api-cpp]: https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/tree/main/parameter-api-cpp
+[opencv-qr-decoder-python]: https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/tree/main/opencv-qr-decoder-python
 [signing-documentation]: https://axiscommunications.github.io/acap-documentation/docs/faq/security.html#sign-acap-applications
 [tensorflow]: https://github.com/tensorflow/serving
 


### PR DESCRIPTION
### Describe your changes

Removing deprecated cpp examples from README.md



