### PR TITLE
Increase build parallelism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ RUN <<EOF
         -DgRPC_BUILD_TESTS=OFF \
         -DgRPC_SSL_PROVIDER=package \
         ../..
-    make -j4 install
+    make "-j$(nproc)" install
 EOF
 
 FROM build_grpc AS build_grpc_arm
@@ -157,7 +157,7 @@ RUN <<EOF
         -DCMAKE_FIND_ROOT_PATH="$SDKTARGETSYSROOT"/usr \
         -DCMAKE_BUILD_TYPE=Release \
         ../..
-    make -j4 install/strip
+    make "-j$(nproc)" install/strip
     cp -r /opt/grpc/third_party/googletest/googletest/include/gtest \
         "$SDKTARGETSYSROOT"/usr/include
 EOF


### PR DESCRIPTION
Use `make -j8` instead of `make -j4`.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
