### PR TITLE
Replace parhand with axparameter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 ARG ARCH=armv7hf
 ARG REPO=axisecp
-ARG VERSION=1.7
+ARG VERSION=1.14
 ARG UBUNTU_VERSION=22.04
 
 FROM arm64v8/ubuntu:${UBUNTU_VERSION} AS containerized_aarch64

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ PKG_CONFIG_CFLAGS_OTHER := $(shell PKG_CONFIG_SYSROOT_DIR="" PKG_CONFIG_PATH=$(P
 PKG_CONFIG_LDFLAGS := $(shell PKG_CONFIG_SYSROOT_DIR="" PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs-only-L $(PKGS))
 PKG_CONFIG_LDLIBS := $(shell PKG_CONFIG_SYSROOT_DIR="" PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs-only-l $(PKGS))
 
-PKGS = gio-2.0 glib-2.0 vdostream
+PKGS = gio-2.0 glib-2.0 vdostream axparameter
 PKG_CONFIG_CFLAGS_I += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags-only-I $(PKGS))
 PKG_CONFIG_CFLAGS_OTHER += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags-only-other $(PKGS))
 PKG_CONFIG_LDFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs-only-L $(PKGS))

--- a/src/parameter.h
+++ b/src/parameter.h
@@ -15,6 +15,7 @@
  */
 
 #include "keyvaluestore.grpc.pb.h"
+#include <axsdk/axparameter.h>
 
 #ifdef TEST
 #define APP_NAME "acapruntimetest"
@@ -35,6 +36,8 @@ class Parameter final : public KeyValueStore::Service {
   private:
     Status GetValues(ServerContext* context, ServerReaderWriter<Response, Request>* stream);
 
+    AXParameter* ax_parameter;
+    GError* _error;
     bool _verbose;
 };
 }  // namespace acap_runtime


### PR DESCRIPTION
### Describe your changes

Since axparameter is now included in the SDK let's use it instead of parhand.

### Issue ticket number and link

- Fixes issue where the parameter API could not be used when running the containerized version of acap-runtime

### Checklist before requesting a review

- [X] I have performed a self-review of my own code
- [X] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
