### PR TITLE
Make parameter API synchronous

### DIFF
--- a/apis/keyvaluestore.proto
+++ b/apis/keyvaluestore.proto
@@ -21,7 +21,7 @@ package keyvaluestore;
 // A simple key-value storage service
 service KeyValueStore {
   // Provides a value for each key request
-  rpc GetValues (stream Request) returns (stream Response) {}
+  rpc GetValues (Request) returns (Response) {}
 }
 
 // The request message containing the key

--- a/src/parameter.h
+++ b/src/parameter.h
@@ -34,7 +34,7 @@ class Parameter final : public KeyValueStore::Service {
     bool Init(const bool verbose);
 
   private:
-    Status GetValues(ServerContext* context, ServerReaderWriter<Response, Request>* stream);
+    Status GetValues(ServerContext* context, const Request* request, Response* response);
 
     AXParameter* ax_parameter;
     GError* _error;


### PR DESCRIPTION
### Describe your changes

To align with usage (i.e the [Parameter API example](https://github.com/AxisCommunications/acap-computer-vision-sdk-examples/tree/main/parameter-api-python), we change the implementation of the Parameter API to synchronous gRPC communication.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
