### PR TITLE
Stop reusing ClientContext instance

### DIFF
--- a/test/parameter_test.cc
+++ b/test/parameter_test.cc
@@ -68,11 +68,12 @@ void Service(int seconds) {
 vector<pair<string, string>> GetValues(unique_ptr<KeyValueStore::Stub>& stub,
                                        const vector<string>& keys) {
     vector<pair<string, string>> values;
-    ClientContext context;
-    Request request;
-    Response response;
 
     for (const auto& key : keys) {
+        ClientContext context;
+        Request request;
+        Response response;
+
         // Key we are sending to the server.
         request.set_key(key);
         auto status = stub->GetValues(&context, request, &response);


### PR DESCRIPTION
Reusing ClientContext in multiple calls causes
assertion failed: call_ == nullptr in client_context.cc

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
