### PR TITLE
Add inotify-tools to build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ apt-get install -y --no-install-recommends \
     pkg-config \
     g++ \
     cmake \
+    inotify-tools \
     libssl-dev \
     gnupg \
     openssl


### PR DESCRIPTION
inotify-wait is handy when modifying a file outside the container and letting that trigger a new build inside it.

### Checklist before requesting a review

- [ ] I have performed a self-review of my own code
- [ ] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
