### PR TITLE
Replace pthread_mutex with std::mutex

### DIFF
--- a/src/inference.h
+++ b/src/inference.h
@@ -17,6 +17,7 @@
 #include "prediction_service.grpc.pb.h"
 #include "video_capture.h"
 #include <larod.h>
+#include <mutex>
 
 namespace acap_runtime {
 class Inference : public tensorflow::serving::PredictionService::Service {
@@ -77,7 +78,7 @@ class Inference : public tensorflow::serving::PredictionService::Service {
     std::map<std::string, larodModel*> _models;
     larodModel* _ppModel;
     larodMap* _ppMap;
-    pthread_mutex_t _mtx;
+    std::mutex _mutex;
     larodTensor** _ppInputTensors;
     larodTensor** _ppOutputTensors;
     larodTensor** _inputTensors;

--- a/src/video_capture.h
+++ b/src/video_capture.h
@@ -22,6 +22,7 @@
 
 #include <deque>
 #include <map>
+#include <mutex>
 
 #include "videocapture.grpc.pb.h"
 
@@ -83,7 +84,7 @@ class Capture final : public videocapture::v1::VideoCapture::Service {
     std::map<unsigned int, Stream> _streams;
     bool _verbose;
     const uint32_t MAX_NBR_SAVED_FRAMES = 3;
-    pthread_mutex_t _mutex;
+    std::mutex _mutex;
 };
 }  // namespace acap_runtime
 


### PR DESCRIPTION
This allows use of std::scoped_lock and a few gotos can be removed.

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
