### PR TITLE
Change GError pointer into a local variable

### DIFF
--- a/src/parameter.cpp
+++ b/src/parameter.cpp
@@ -30,11 +30,11 @@ namespace acap_runtime {
 
 Parameter::Parameter(bool verbose) : _verbose(verbose) {
     TRACELOG << "Init" << endl;
-    _error = NULL;
-    ax_parameter = ax_parameter_new(APP_NAME, &_error);
+    GError* error = nullptr;
+    ax_parameter = ax_parameter_new(APP_NAME, &error);
     if (ax_parameter == NULL) {
-        ERRORLOG << "Error when creating axparameter: " << _error->message << endl;
-        g_clear_error(&_error);
+        ERRORLOG << "Error when creating axparameter: " << error->message << endl;
+        g_clear_error(&error);
         throw runtime_error{"Could not Init Parameter Service"};
     }
 }
@@ -51,10 +51,11 @@ Status Parameter::GetValues(ServerContext* context, const Request* request, Resp
         return Status(StatusCode::INVALID_ARGUMENT, "No valid input request");
     }
     char* parameter_value = NULL;
-    if (!ax_parameter_get(ax_parameter, parameter_key, &parameter_value, &_error)) {
-        ERRORLOG << "Error when getting axparameter: " << _error->message << endl;
+    GError* error = nullptr;
+    if (!ax_parameter_get(ax_parameter, parameter_key, &parameter_value, &error)) {
+        ERRORLOG << "Error when getting axparameter: " << error->message << endl;
         parameter_value = g_strdup("");
-        g_clear_error(&_error);
+        g_clear_error(&error);
     }
     TRACELOG << parameter_key << ": " << parameter_value << endl;
 

--- a/src/parameter.h
+++ b/src/parameter.h
@@ -40,7 +40,6 @@ class Parameter final : public keyvaluestore::KeyValueStore::Service {
     Status GetValues(ServerContext* context, const Request* request, Response* response) override;
 
     AXParameter* ax_parameter;
-    GError* _error;
     bool _verbose;
 };
 }  // namespace acap_runtime


### PR DESCRIPTION
The _error member did not hold any state that the class needed to preserve,
so it should not be a class member.


### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have verified that my code follows the style already available in the repository
- [ ] I have made corresponding changes to the documentation
