### PR TITLE
Set default workflow token permissions to read-only

### DIFF
--- a/.github/workflows/build-proto-image.yml
+++ b/.github/workflows/build-proto-image.yml
@@ -32,6 +32,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   build_proto_image:
     name: Build Proto Image

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,6 +34,9 @@ on:
     branches:
       - "main"
 
+permissions:
+  contents: read
+
 jobs:
   general_settings:
     name: Set general settings

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Token-Permissions** remedy.

It sets the default workflow token to read-only by adding a top-level `permissions` block to workflows that lacked one:

- `.github/workflows/build-proto-image.yml`
- `.github/workflows/ci-cd.yml`
- `.github/workflows/lint.yml`

Any job that needs more than read access must be granted those permissions at the job level, otherwise it may fail.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#token-permissions) for details.