### PR TITLE
Add Renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices", ":prHourlyLimitNone"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Auto-merge non-breaking SemVer updates (minor and patch) for stable (>= 1.0.0) dependencies",
+      "matchUpdateTypes": ["minor", "patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
+      "description": "Enforce a 14-day minimumReleaseAge for all update types, overriding any inherited preset configuration",
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "pinDigest", "digest"],
+      "minimumReleaseAge": "14 days"
+    }
+  ],
+  "rebaseWhen": "behind-base-branch",
+  "vulnerabilityAlerts": {
+    "labels": ["security"]
+  },
+  "minimumReleaseAge": "14 days",
+  "prCreation": "not-pending",
+  "dependencyDashboard": true
+}


### PR DESCRIPTION
This pull request applies the OSSF Scorecard **Dependency-Update-Tool** remedy.

It adds a Renovate configuration at `.github/renovate.json` so dependency updates are proposed automatically.

Renovate must still be enabled for this repository (ask the GitHub Governance team) for the configuration to take effect.

See the [OSSF Scorecard guidance](https://github.com/AxisCommunications/github-governance/blob/main/ossf-scorecard/README.md#dependency-update-tool) for details.